### PR TITLE
WIP: Update for MediaWiki 1.35

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,14 @@
             "email": "mail@adrianheine.de"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/lucaswerkmeister/wikibase-forms"
+        }
+    ],
     "require": {
-      "adrianheine/wikibase-forms": "^0.1.0",
+      "adrianheine/wikibase-forms": "dev-data-values",
       "php": "^7.0",
       "wikibase/data-model": "^9.5.1|^8.0.0|^7.3.0",
       "wikibase/data-model-services": "^5.2.0|^4.0.0|^3.9.0"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
       "adrianheine/wikibase-forms": "^0.1.0",
       "php": "^7.0",
-      "wikibase/data-model": "^7.3.0",
-      "wikibase/data-model-services": "^3.9.0"
+      "wikibase/data-model": "^9.5.1|^8.0.0|^7.3.0",
+      "wikibase/data-model-services": "^5.2.0|^4.0.0|^3.9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/MediaWikiFormProvider.php
+++ b/src/MediaWikiFormProvider.php
@@ -22,7 +22,8 @@ namespace MwWikibaseForms;
 
 use ContentHandler;
 use MediaWiki\MediaWikiServices;
-use Revision;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
 use Title;
 use Wikibase\DataModel\Entity\EntityIdParser;
 use WikibaseForms\FormParser;
@@ -43,8 +44,8 @@ class MediaWikiFormProvider implements FormProvider {
 			throw new Exception( "Form not found" );
 		}
 		$wikiPage = WikiPage::factory( $title );
-		$revision = $wikiPage->getRevision();
-		$content = $revision->getContent( Revision::RAW );
+		$revision = $wikiPage->getRevisionRecord();
+		$content = $revision->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 		$text = ContentHandler::getContentText( $content );
 		$formParser = new FormParser( $this->entityIdParser );
 		$form = $formParser->parse( $text );


### PR DESCRIPTION
Declare compatibility with more recent versions of Wikibase Data Model (Services), and stop using the deprecated Revision class.

---

WIP because this also requires adrianheine/wikibase-forms#1 to work; you can test it with the following additional patch:

```diff
diff --git a/composer.json b/composer.json
index 2ed1cc3..9641a22 100644
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,14 @@
             "email": "mail@adrianheine.de"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/lucaswerkmeister/wikibase-forms"
+        }
+    ],
     "require": {
-      "adrianheine/wikibase-forms": "^0.1.0",
+      "adrianheine/wikibase-forms": "dev-data-values",
       "php": "^7.0",
       "wikibase/data-model": "^9.5.1|^8.0.0|^7.3.0",
       "wikibase/data-model-services": "^5.2.0|^4.0.0|^3.9.0"
```